### PR TITLE
Styling changes for kada.fi

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -38,17 +38,17 @@
         </div>
       </div>
       <div class="row">
-        <div class="col-xs-12 col-md-6 text-center">
+        <div class="col-xs-12 col-md-3 col-md-offset-3 text-center">
           <a href="http://www.kuntaliitto.fi/">
-            <img src="/images/kuntaliitto.png" alt="Kuntaliitto" class="brand brand--kuntaliitto" style="width: 260px;">
+            <img src="/images/kuntaliitto.png" alt="Kuntaliitto" class="brand brand--kuntaliitto">
           </a>
           <p><strong>Kuntaliitto</strong></p>
           <p>Tommi Karttaavi<br /><a href="mailto:tommi.karttaavi@kuntaliitto.fi">tommi.karttaavi@kuntaliitto.fi</a><br />050 563 3935</p>
           <p><a href="http://www.kuntaliitto.fi/">www.kuntaliitto.fi</a></p>
         </div>
-        <div class="col-xs-12 col-md-6 text-center">
+        <div class="col-xs-12 col-md-3 text-center">
           <a href="http://www.turku.fi/">
-            <img src="/images/turku.png" alt="Turku" class="brand brand--turku" style="height: 200px;">
+            <img src="/images/turku.png" alt="Turku" class="brand brand--turku">
           </a>
           <p><strong>Turun kaupunki</strong></p>
           <p>Sanna Moisala<br /><a href="mailto:sanna.moisala@turku.fi">sanna.moisala@turku.fi</a><br />040 159 4874</p>

--- a/styles/app.min.css
+++ b/styles/app.min.css
@@ -5840,29 +5840,37 @@ svg {
   max-width: 100%; }
 
 .brand--turku {
-  max-width: 320px; }
+  height: 200px;
+  max-width: 320px;
+}
 
 .brand--avoltus {
-  margin-bottom: 1em;
+  margin-bottom: 2.1em;
   margin-top: 2.2em;
   width: 215px; }
 
 .brand--citrus {
+  margin-bottom: 1.4em;
   margin-top: 1.2em;
   width: 170px; }
 
 .brand--druid {
-  margin-bottom: 0.4em;
+  margin-bottom: 0.7em;
   margin-top: 0.6em;
   width: 175px; }
 
 .brand--wunderkraut {
-  margin-bottom: 0.3em;
-  margin-top: 0.9em;
+  margin-top: -1.5em;
   width: 264px; }
   @media screen and (max-width: 991px) {
     .brand--wunderkraut {
       padding-left: 0.6em; } }
+
+.brand--kuntaliitto {
+  margin-bottom: 5em;
+  margin-top: 4em;
+  width: 260px;
+}
 
 .features {
   margin: 20px auto;


### PR DESCRIPTION
Changes:
- Kuntaliitto and Turku logos are same width as other and are centered.
- First row below logos are about same level.
- Moved styles from html to css.
