### PR TITLE
Disabled value "domain_sitename_override" in domains feature.

### DIFF
--- a/code/modules/features/kada_domains_feature/kada_domains_feature.strongarm.inc
+++ b/code/modules/features/kada_domains_feature/kada_domains_feature.strongarm.inc
@@ -239,7 +239,7 @@ node/%n/outline';
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'domain_sitename_override';
-  $strongarm->value = 1;
+  $strongarm->value = 0;
   $export['domain_sitename_override'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
Using the domain_sitename_override setting prevents using site name values defined at site-information page. This also prevents using localized values for site name.