### PR TITLE
Remove domain defaultness from feature

### DIFF
--- a/code/modules/features/kada_domains_feature/kada_domains_feature.domains.inc
+++ b/code/modules/features/kada_domains_feature/kada_domains_feature.domains.inc
@@ -15,7 +15,7 @@ function kada_domains_feature_domain_default_domains() {
     'scheme' => 'http',
     'valid' => 1,
     'weight' => -1,
-    'is_default' => 1,
+    'is_default' => 0,
     'machine_name' => 'local_kada_fi',
   );
 


### PR DESCRIPTION
Having a default domain set in a base Feature causes `features-revert-all` to break both the current deployment and access to the site. In effect, once this erroneous defaultness gets reverted from Feature code to the Drupal database, Drupal begins to redirect all traffic to that domain.

This PR fixes that by simply forcing the KADA domain to *never* be the default domain.