### PR TITLE
Enable Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: php
+
+php:
+  - 5.6
+  - 7.1
+  - 7.2
+  - nightly
+
+matrix:
+  fast_finish: true
+  allow_failures:
+  - php: nightly
+
+before_install:
+  # Build the application.
+  - ./build.sd new

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,8 @@ cache:
   - $HOME/.composer/cache
 
 before_install:
-  - composer self-update
+  - export PATH="$HOME/.composer/vendor/bin:$PATH"
 
-  # Install Drush.
   - composer global require drush/drush:~8.1.5
-  # DEBUG: Confirm Drush is installed.
-  - drush version
 
-  # Build the application.
   - ./build.sh new

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,13 @@ matrix:
   allow_failures:
   - php: nightly
 
+cache:
+  directories:
+  - $HOME/.composer/cache
+
 before_install:
+  - composer self-update
+
   # Install Drush.
   - composer global require drush/drush:~8.1.5
   # DEBUG: Confirm Drush is installed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,8 @@ matrix:
   - php: nightly
 
 before_install:
+  # Install Drush.
+  - composer global require drush/drush:~8.1.5
+
   # Build the application.
   - ./build.sh new

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ matrix:
 
 before_install:
   # Build the application.
-  - ./build.sd new
+  - ./build.sh new

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
 before_install:
   # Install Drush.
   - composer global require drush/drush:~8.1.5
+  # DEBUG: Confirm Drush is installed.
+  - drush version
 
   # Build the application.
   - ./build.sh new

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,6 @@ before_install:
   - composer global require drush/drush:~8.1.5
 
   - ./build.sh new
+
+script:
+  - echo "There are no tests yet, but the build passed."

--- a/build.sh
+++ b/build.sh
@@ -434,7 +434,8 @@ class Maker:
 	# Ensure directories exist
 	def _precheck(self):
 		# Most of the time a files directory will already exist, but primarily for initial builds, it won't.
-		os.mkdir('files')
+		if not os.path.isdir('files'):
+			os.mkdir('files')
 
 		# Remove old build it if exists
 		if os.path.isdir(self.temp_build_dir):

--- a/build.sh
+++ b/build.sh
@@ -433,6 +433,9 @@ class Maker:
 
 	# Ensure directories exist
 	def _precheck(self):
+		# Most of the time a files directory will already exist, but primarily for initial builds, it won't.
+		os.mkdir('files')
+
 		# Remove old build it if exists
 		if os.path.isdir(self.temp_build_dir):
 			shutil.rmtree(self.temp_build_dir)

--- a/conf/kadaproject.make
+++ b/conf/kadaproject.make
@@ -80,7 +80,7 @@ libraries[colorbox][download][url] = https://github.com/jackmoore/colorbox/archi
 
 ; Openlayers library
 libraries[openlayers][download][type] = get
-libraries[openlayers][download][url] = https://github.com/openlayers/openlayers/releases/download/release-2.13.1/OpenLayers-2.13.1.zip
+libraries[openlayers][download][url] = https://github.com/openlayers/openlayers/archive/release-2.13.1.zip
 
 ; Contrib modules
 ; ------------

--- a/conf/kadaproject.make
+++ b/conf/kadaproject.make
@@ -80,7 +80,7 @@ libraries[colorbox][download][url] = https://github.com/jackmoore/colorbox/archi
 
 ; Openlayers library
 libraries[openlayers][download][type] = get
-libraries[openlayers][download][url] = https://github.com/openlayers/openlayers/archive/release-2.13.1.zip
+libraries[openlayers][download][url] = https://github.com/openlayers/ol2/archive/release-2.13.1.zip
 
 ; Contrib modules
 ; ------------


### PR DESCRIPTION
This PR enables the project to be tested using Travis CI builds. For the moment, it just builds the application, as there are no tests, but additional features can be added incrementally if and when they are needed.

For this to work, an administrator of this repository must enable Travis CI integration at https://travis-ci.org/profile, after logging into Travis via Github.

In addition to the Travis CI integration, in order to make the build work, the Python-based build script now creates the files directory if it does not exist yet, and the OpenLayers release URL was updated to Github's latest format.